### PR TITLE
e1: highlight outdated extension versions (fix logic)

### DIFF
--- a/sql/e1_extensions.sql
+++ b/sql/e1_extensions.sql
@@ -4,8 +4,7 @@ select
   ae.name,
   installed_version,
   default_version,
-  extversion as available_version,
-  case when installed_version <> extversion then 'OLD' end as actuality
+  case when installed_version <> default_version then 'OLD' end as actuality
 from pg_extension e
 join pg_available_extensions ae on extname = ae.name
 order by ae.name;

--- a/sql/e1_extensions.sql
+++ b/sql/e1_extensions.sql
@@ -4,7 +4,7 @@ select
   ae.name,
   installed_version,
   default_version,
-  case when installed_version <> default_version then 'OLD' end as actuality
+  case when installed_version <> default_version then 'OLD' end as is_old
 from pg_extension e
 join pg_available_extensions ae on extname = ae.name
 order by ae.name;


### PR DESCRIPTION
It is incorrect to compare `pg_available_extensions.installed_version` to `pg_extension.extversion`, it should be compared to `pg_available_extensions.default_version`. It led to incorrectly working `actuality` flag – at all times it was empty.

This commit fixes it. Also, `available_extension` column is removed – its logic was wrong from the very beginning.

Example:
- before fix:
```
        name        | installed_version | default_version | available_version | actuality
--------------------+-------------------+-----------------+-------------------+-----------
 pg_stat_statements | 1.2               | 1.4             | 1.2               |
 plpgsql            | 1.0               | 1.0             | 1.0               |
(2 rows)
```

- after fix:
```
        name        | installed_version | default_version | actuality
--------------------+-------------------+-----------------+-----------
 pg_stat_statements | 1.2               | 1.4             | OLD
 plpgsql            | 1.0               | 1.0             |
(2 rows)
```