### PR TITLE
Improve i1,i2,i5 and b1 reports

### DIFF
--- a/sql/b1_table_estimation.sql
+++ b/sql/b1_table_estimation.sql
@@ -75,7 +75,13 @@ select
   greatest(last_autovacuum, last_vacuum)::timestamp(0)::text 
     || case greatest(last_autovacuum, last_vacuum)
       when last_autovacuum then ' (auto)'
-    else '' end as "Last Vaccuum"
+    else '' end as "Last Vaccuum",
+  (
+    select
+      coalesce(substring(array_to_string(reloptions, ' ') from 'fillfactor=([0-9]+)')::smallint, 100)
+    from pg_class
+    where oid = tblid
+  ) as fillfactor
 from step4
 order by real_size desc nulls last
 ;

--- a/sql/b1_table_estimation.sql
+++ b/sql/b1_table_estimation.sql
@@ -81,7 +81,7 @@ select
       coalesce(substring(array_to_string(reloptions, ' ') from 'fillfactor=([0-9]+)')::smallint, 100)
     from pg_class
     where oid = tblid
-  ) as "Fill Factor"
+  ) as "Fillfactor"
 from step4
 order by real_size desc nulls last
 ;

--- a/sql/b1_table_estimation.sql
+++ b/sql/b1_table_estimation.sql
@@ -81,7 +81,7 @@ select
       coalesce(substring(array_to_string(reloptions, ' ') from 'fillfactor=([0-9]+)')::smallint, 100)
     from pg_class
     where oid = tblid
-  ) as fillfactor
+  ) as "Fill Factor"
 from step4
 order by real_size desc nulls last
 ;

--- a/sql/b1_table_estimation.sql
+++ b/sql/b1_table_estimation.sql
@@ -72,17 +72,17 @@ select
   case
     when extra_size::numeric >= 0
       then '~' || pg_size_pretty(extra_size::numeric)::text || ' (' || round(extra_ratio::numeric, 2)::text || '%)'
-    else '-'
+    else null
   end  as "Extra",
   case
     when bloat_size::numeric >= 0
       then '~' || pg_size_pretty(bloat_size::numeric)::text || ' (' || round(bloat_ratio::numeric, 2)::text || '%)'
-    else '-'
+    else null
   end as "Bloat estimate",
   case
     when (real_size - bloat_size)::numeric >=0
       then '~' || pg_size_pretty((real_size - bloat_size)::numeric)
-      else '-'
+      else null
    end as "Live",
   greatest(last_autovacuum, last_vacuum)::timestamp(0)::text 
     || case greatest(last_autovacuum, last_vacuum)

--- a/sql/b2_btree_estimation.sql
+++ b/sql/b2_btree_estimation.sql
@@ -101,9 +101,21 @@ select
     coalesce(nullif(schema_name, 'public') || '.', '') || table_name
   ) as "Index (Table)",
   pg_size_pretty(real_size::numeric) as "Size",
-  '~' || pg_size_pretty(extra_size::numeric)::text || ' (' || round(extra_ratio::numeric, 2)::text || '%)' as "Extra",
-  '~' || pg_size_pretty(bloat_size::numeric)::text || ' (' || round(bloat_ratio::numeric, 2)::text || '%)' as "Bloat",
-  '~' || pg_size_pretty((real_size - bloat_size)::numeric) as "Live",
+  case
+    when extra_size::numeric >= 0
+      then '~' || pg_size_pretty(extra_size::numeric)::text || ' (' || round(extra_ratio::numeric, 2)::text || '%)'
+    else '-'
+  end  as "Extra",
+  case
+    when bloat_size::numeric >= 0
+      then '~' || pg_size_pretty(bloat_size::numeric)::text || ' (' || round(bloat_ratio::numeric, 2)::text || '%)'
+    else '-'
+  end as "Bloat",
+  case
+    when (real_size - bloat_size)::numeric >=0
+      then '~' || pg_size_pretty((real_size - bloat_size)::numeric)
+      else '-'
+   end as "Live",
   fillfactor
 from step4
 order by real_size desc nulls last

--- a/sql/b2_btree_estimation.sql
+++ b/sql/b2_btree_estimation.sql
@@ -104,17 +104,17 @@ select
   case
     when extra_size::numeric >= 0
       then '~' || pg_size_pretty(extra_size::numeric)::text || ' (' || round(extra_ratio::numeric, 2)::text || '%)'
-    else '-'
+    else null
   end  as "Extra",
   case
     when bloat_size::numeric >= 0
       then '~' || pg_size_pretty(bloat_size::numeric)::text || ' (' || round(bloat_ratio::numeric, 2)::text || '%)'
-    else '-'
+    else null
   end as "Bloat",
   case
     when (real_size - bloat_size)::numeric >=0
       then '~' || pg_size_pretty((real_size - bloat_size)::numeric)
-      else '-'
+      else null
    end as "Live",
   fillfactor
 from step4

--- a/sql/i1_rare_indexes.sql
+++ b/sql/i1_rare_indexes.sql
@@ -39,7 +39,6 @@ SELECT schemaname, tablename, indexname,
         as scans_per_write,
     pg_size_pretty(index_bytes) as index_size,
     pg_size_pretty(table_size) as table_size,
-    table_size as table_bytes,
     idx_is_btree, index_bytes
     FROM indexes
     JOIN table_scans
@@ -87,9 +86,7 @@ SELECT
     index_size,
     table_size,
     idx_scan,
-    all_scans,
-    index_bytes,
-    table_bytes
+    all_scans
 FROM index_groups
 ;
 

--- a/sql/i1_rare_indexes.sql
+++ b/sql/i1_rare_indexes.sql
@@ -76,7 +76,16 @@ WHERE
     AND NOT idx_is_btree
     AND index_bytes > 100000000
 ORDER BY grp, index_bytes DESC )
-SELECT reason, schemaname, tablename, indexname,
-    index_scan_pct, scans_per_write, index_size, table_size
+SELECT 
+    reason,
+    schemaname as schema_name,
+    tablename as table_name,
+    indexname as index_name,
+    index_scan_pct,
+    scans_per_write,
+    index_size,
+    table_size,
+    idx_scan,
+    all_scans
 FROM index_groups;
 

--- a/sql/i1_rare_indexes.sql
+++ b/sql/i1_rare_indexes.sql
@@ -85,6 +85,7 @@ SELECT
     index_scan_pct,
     scans_per_write,
     index_size,
+    table_size,
     idx_scan,
     all_scans,
     index_bytes,

--- a/sql/i1_rare_indexes.sql
+++ b/sql/i1_rare_indexes.sql
@@ -39,6 +39,7 @@ SELECT schemaname, tablename, indexname,
         as scans_per_write,
     pg_size_pretty(index_bytes) as index_size,
     pg_size_pretty(table_size) as table_size,
+    table_size as table_bytes,
     idx_is_btree, index_bytes
     FROM indexes
     JOIN table_scans
@@ -84,8 +85,10 @@ SELECT
     index_scan_pct,
     scans_per_write,
     index_size,
-    table_size,
     idx_scan,
-    all_scans
-FROM index_groups;
+    all_scans,
+    index_bytes,
+    table_bytes
+FROM index_groups
+;
 

--- a/sql/i2_redundant_indexes.sql
+++ b/sql/i2_redundant_indexes.sql
@@ -10,25 +10,51 @@
 -- is usually very different from master).
 
 with index_data as (
-  select *, string_to_array(indkey::text,' ') as key_array,array_length(string_to_array(indkey::text,' '),1) as nkeys
+  select
+    *,
+    indkey::text as columns,
+    array_to_string(indclass, ', ') as opclasses
   from pg_index
 ), redundant as (
   select
+    i2.indrelid::regclass::text as table_name,
+    i2.indexrelid::regclass::text as index_name,
+    am1.amname as access_method,
     format('redundant to index: %I', i1.indexrelid::regclass)::text as reason,
-    i2.indrelid::regclass::text as tablename,
-    i2.indexrelid::regclass::text as indexname,
-    pg_get_indexdef(i1.indexrelid) main_indexdef,
-    pg_get_indexdef(i2.indexrelid) indexdef,
-    pg_size_pretty(pg_relation_size(i2.indexrelid)) size,
-    i2.indexrelid
+    pg_get_indexdef(i1.indexrelid) main_index_def,
+    pg_size_pretty(pg_relation_size(i1.indexrelid)) main_index_size,
+    pg_get_indexdef(i2.indexrelid) index_def,
+    pg_size_pretty(pg_relation_size(i2.indexrelid)) index_size,
+    s.idx_scan as index_usage
   from
     index_data as i1
-    join index_data as i2 on i1.indrelid = i2.indrelid and i1.indexrelid <> i2.indexrelid
+    join index_data as i2 on (
+        i1.indrelid = i2.indrelid /* same table */
+        and i1.indexrelid <> i2.indexrelid /* NOT same index */
+    )
+    inner join pg_opclass op1 on i1.indclass[0] = op1.oid
+    inner join pg_opclass op2 on i2.indclass[0] = op2.oid
+    inner join pg_am am1 on op1.opcmethod = am1.oid
+    inner join pg_am am2 on op2.opcmethod = am2.oid
+    join pg_stat_user_indexes as s on s.indexrelid = i2.indexrelid
   where
-    (regexp_replace(i1.indpred, 'location \d+', 'location', 'g') IS NOT DISTINCT FROM regexp_replace(i2.indpred, 'location \d+', 'location', 'g'))
-    and (regexp_replace(i1.indexprs, 'location \d+', 'location', 'g') IS NOT DISTINCT FROM regexp_replace(i2.indexprs, 'location \d+', 'location', 'g'))
-    and ((i1.nkeys > i2.nkeys and not i2.indisunique) OR (i1.nkeys=i2.nkeys and ((i1.indisunique and i2.indisunique and (i1.indexrelid>i2.indexrelid)) or (not i1.indisunique and not i2.indisunique and (i1.indexrelid>i2.indexrelid)) or (i1.indisunique and not i2.indisunique))))
-    and i1.key_array[1:i2.nkeys]=i2.key_array
+    not i1.indisprimary -- index 1 is not primary
+    and not ( -- skip if index1 is primary or uniq  and  index2 is primary or unique
+        (i1.indisprimary or i1.indisunique)
+        and (not i2.indisprimary or not i2.indisunique)
+    )
+    and  am1.amname = am2.amname -- same access type
+    and (
+      i2.columns like (i1.columns || '%') -- index 2 include all columns from index 1
+      or i1.columns = i2.columns -- index1 and index 2 include same columns
+    )
+    and (
+      i2.opclasses like (i1.opclasses || '%')
+      or i1.opclasses = i2.opclasses
+    )
+    -- index expressions is same
+    and pg_get_expr(i1.indexprs, i1.indrelid) is not distinct from pg_get_expr(i2.indexprs, i2.indrelid)
+    -- index predicates is same
+    and pg_get_expr(i1.indpred, i1.indrelid) is not distinct from pg_get_expr(i2.indpred, i2.indrelid)
 )
 select * from redundant;
-

--- a/sql/i2_redundant_indexes.sql
+++ b/sql/i2_redundant_indexes.sql
@@ -43,14 +43,14 @@ with index_data as (
     join pg_class as irel on irel.oid = i2.indexrelid
   where
     not i1.indisprimary -- index 1 is not primary
-    and not ( -- skip if index1 is primary or uniq  and  index2 is primary or unique
+    and not ( -- skip if index1 is (primary or uniq) and is NOT (primary and uniq)
         (i1.indisprimary or i1.indisunique)
         and (not i2.indisprimary or not i2.indisunique)
     )
     and  am1.amname = am2.amname -- same access type
     and (
-      i2.columns like (i1.columns || '%') -- index 2 include all columns from index 1
-      or i1.columns = i2.columns -- index1 and index 2 include same columns
+      i2.columns like (i1.columns || '%') -- index 2 includes all columns from index 1
+      or i1.columns = i2.columns -- index1 and index 2 includes same columns
     )
     and (
       i2.opclasses like (i1.opclasses || '%')

--- a/sql/i4_invalid_indexes.sql
+++ b/sql/i4_invalid_indexes.sql
@@ -15,7 +15,11 @@ select
     pn.nspname as schema_name,
     pct.relname as table_name,
     pg_size_pretty(pg_relation_size(pidx.indexrelid)) index_size,
-    format('DROP INDEX CONCURRENTLY %s; -- %s, table %s', pidx.indexrelid::regclass::text, 'Invalid index', pct.relname) as drop_code,
+    format(
+      'DROP INDEX CONCURRENTLY %s; -- %s, table %s',
+      pidx.indexrelid::regclass::text,
+      'Invalid index',
+      pct.relname) as drop_code,
     replace(
       format('%s; -- table %s', pg_get_indexdef(pidx.indexrelid), pct.relname),
       'CREATE INDEX',

--- a/sql/i4_invalid_indexes.sql
+++ b/sql/i4_invalid_indexes.sql
@@ -14,6 +14,7 @@ select
     pci.relname as index_name,
     pn.nspname as schema_name,
     pct.relname as table_name,
+    pg_size_pretty(pg_relation_size(pidx.indexrelid)) index_size,
     format('DROP INDEX CONCURRENTLY %s; -- %s, table %s', pidx.indexrelid::regclass::text, 'Invalid index', pct.relname) as drop_code,
     replace(
       format('%s; -- table %s', pg_get_indexdef(pidx.indexrelid), pct.relname),

--- a/sql/i4_invalid_indexes.sql
+++ b/sql/i4_invalid_indexes.sql
@@ -13,7 +13,13 @@ select
     coalesce(nullif(pn.nspname, 'public') || '.', '') || pct.relname as "relation_name",
     pci.relname as index_name,
     pn.nspname as schema_name,
-    pct.relname as table_name
+    pct.relname as table_name,
+    format('DROP INDEX CONCURRENTLY %s; -- %s, table %s', pidx.indexrelid::regclass::text, 'Invalid index', pct.relname) as drop_code,
+    replace(
+      format('%s; -- table %s', pg_get_indexdef(pidx.indexrelid), pct.relname),
+      'CREATE INDEX',
+      'CREATE INDEX CONCURRENTLY'
+    ) as revert_code
 from pg_index pidx
 join pg_class as pci on pci.oid = pidx.indexrelid
 join pg_class as pct on pct.oid = pidx.indrelid


### PR DESCRIPTION
- The condition for redundant indexes list reworked
- main_index_size, index_size, index_usage columns added to i2
- Report i5 reworked  on base changes in i2
- Drop and revert code added for invalid indexes
- b1: fillfactor column added
- b1: `Bloat` column renamed to `Bloat estimate` 
- b1 and b2: `-` instead negative value of `Bloat`, `Extra`, `Live columns`