### PR TITLE
Improve version handling in SQL scripts.

### DIFF
--- a/init/generate.sh
+++ b/init/generate.sh
@@ -16,7 +16,7 @@ cat > "$WARMUP" <<- VersCheck
   select 1/0;
 \endif
 
-select regexp_replace(version(), '^PostgreSQL (\d+\.\d+).*$', e'\\\\1')::numeric >= 10 as postgres_dba_pgvers_10plus \gset
+select current_setting('server_version_num')::integer >= 100000 as postgres_dba_pgvers_10plus \gset
 \if :postgres_dba_pgvers_10plus
   \set postgres_dba_last_wal_receive_lsn pg_last_wal_receive_lsn
   \set postgres_dba_last_wal_replay_lsn pg_last_wal_replay_lsn
@@ -28,7 +28,7 @@ select regexp_replace(version(), '^PostgreSQL (\d+\.\d+).*$', e'\\\\1')::numeric
 \endif
 
 -- TODO: improve work with custom GUCs for Postgres 9.5 and older
-select regexp_replace(version(), '^PostgreSQL (\d+\.\d+).*$', e'\\\\1')::numeric >= 9.6 as postgres_dba_pgvers_96plus \gset
+select current_setting('server_version_num')::integer >= 90600 as postgres_dba_pgvers_96plus \gset
 \if :postgres_dba_pgvers_96plus
   select coalesce(current_setting('postgres_dba.wide', true), 'off') = 'on' as postgres_dba_wide \gset
 \else

--- a/sql/t1_tuning.sql
+++ b/sql/t1_tuning.sql
@@ -32,8 +32,6 @@ select :postgres_dba_t1_location = 1 as postgres_dba_t1_location_onpremise \gset
 select :postgres_dba_t1_location = 2 as postgres_dba_t1_location_ec2 \gset
 select :postgres_dba_t1_location = 3 as postgres_dba_t1_location_rds \gset
 
-select regexp_replace(version(), '^PostgreSQL (\d+\.\d+).*$', e'\\1')::numeric as postgres_dba_t1_pg_version \gset
-
 \echo
 \echo
 

--- a/warmup.psql
+++ b/warmup.psql
@@ -4,7 +4,7 @@
   select 1/0;
 \endif
 
-select regexp_replace(version(), '^PostgreSQL (\d+\.\d+).*$', e'\\1')::numeric >= 10 as postgres_dba_pgvers_10plus \gset
+select current_setting('server_version_num')::integer >= 100000 as postgres_dba_pgvers_10plus \gset
 \if :postgres_dba_pgvers_10plus
   \set postgres_dba_last_wal_receive_lsn pg_last_wal_receive_lsn
   \set postgres_dba_last_wal_replay_lsn pg_last_wal_replay_lsn
@@ -16,7 +16,7 @@ select regexp_replace(version(), '^PostgreSQL (\d+\.\d+).*$', e'\\1')::numeric >
 \endif
 
 -- TODO: improve work with custom GUCs for Postgres 9.5 and older
-select regexp_replace(version(), '^PostgreSQL (\d+\.\d+).*$', e'\\1')::numeric >= 9.6 as postgres_dba_pgvers_96plus \gset
+select current_setting('server_version_num')::integer >= 90600 as postgres_dba_pgvers_96plus \gset
 \if :postgres_dba_pgvers_96plus
   select coalesce(current_setting('postgres_dba.wide', true), 'off') = 'on' as postgres_dba_wide \gset
 \else


### PR DESCRIPTION
Avoid parsing version() output with regexps, as it breaks for non-released versions (i.e. devel or beta). Get the value from the server_version_num instead. Remove the version fetch from t1_tuning.sql, as it seems to serve no purpose there.