### PR TITLE
CircleCI tests refactoring. Support Postgres 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/postgres_dba
     docker:
-      - image: circleci/postgres:12
+      - image: postgres:12
         environment:
           - PGHOST: 127.0.0.1
           - PGUSER: root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ workflows:
   version: 2
   test:
     jobs:
-      - postgres-9.6
-      - postgres-10
-      - postgres-11
-      - postgres-12
+      - test-9.6
+      - test-10
+      - test-11
+      - test-12
 
 jobs:
   test-9.6: &test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Init DB
+          name: Init Postgres cluster
           command: |
             pg_createcluster $POSTGRES_VERSION main
             echo 'local all all trust' > /etc/postgresql/$POSTGRES_VERSION/main/pg_hba.conf

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ jobs:
   build:
     working_directory: ~/postgres_dba
     docker:
-      - image: postgres:12
+      - image: postgres:11
         environment:
-          - POSTGRES_VERSION: 12
+          - POSTGRES_VERSION: 11
     steps:
       - checkout
       - run:
@@ -13,20 +13,24 @@ jobs:
           command: |
             pg_createcluster $POSTGRES_VERSION main
             echo 'local all all trust' > /etc/postgresql/$POSTGRES_VERSION/main/pg_hba.conf
+            echo "shared_preload_libraries='pg_stat_statements'" >> /etc/postgresql/$POSTGRES_VERSION/main/postgresql.conf
             pg_ctlcluster $POSTGRES_VERSION main start
       - run:
           name: Prepare DB
           command: |
             psql -U postgres -c 'create database test'
+            psql -U postgres test -c 'create extension pg_stat_statements'
             psql -U postgres test -c "create table align1 as select 1::int4, 2::int8, 3::int4 as more from generate_series(1, 100000) _(i);"
             psql -U postgres test -c "create table align2 as select 1::int4, 3::int4 as more, 2::int8 from generate_series(1, 100000) _(i);"
       - run:
           name: Tests
           command: |
-            #  echo "\set postgres_dba_wide true" > ~/.psqlrc
-            #for f in ~/postgres_dba/sql/*; do psql -U postgres test -f "$f">/dev/null; done
-            #echo "\set postgres_dba_wide false" > ~/.psqlrc
-            #for f in ~/postgres_dba/sql/*; do psql -U postgres test -f "$f">/dev/null; done
+            echo "\set postgres_dba_wide true" > ~/.psqlrc
+            echo "\set postgres_dba_interactive_mode false" >> ~/.psqlrc
+            for f in ~/postgres_dba/sql/*; do psql -U postgres test -f ~/postgres_dba/warmup.psql -f "$f">/dev/null; done
+            echo "\set postgres_dba_wide false" > ~/.psqlrc
+            echo "\set postgres_dba_interactive_mode false" >> ~/.psqlrc
+            for f in ~/postgres_dba/sql/*; do psql -U postgres test -f ~/postgres_dba/warmup.psql -f "$f">/dev/null; done
             diff -b test/regression/0_node.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/0_node.sql | grep Role)
             diff -b test/regression/p1_alignment_padding.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/p1_alignment_padding.sql | grep align)
             diff -b test/regression/a1_activity.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/a1_activity.sql | grep User)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,21 @@
 version: 2
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - postgres-9.6
+      - postgres-10
+      - postgres-11
+      - postgres-12
+
 jobs:
-  build:
+  test-9.6: &test-template
     working_directory: ~/postgres_dba
     docker:
-      - image: postgres:11
+      - image: postgres:9.6
         environment:
-          - POSTGRES_VERSION: 11
+          - POSTGRES_VERSION: 9.6
     steps:
       - checkout
       - run:
@@ -35,3 +45,21 @@ jobs:
             diff -b test/regression/0_node.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/0_node.sql | grep Role)
             diff -b test/regression/p1_alignment_padding.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/p1_alignment_padding.sql | grep align)
             diff -b test/regression/a1_activity.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/a1_activity.sql | grep User)
+  test-10:
+    <<: *test-template
+    docker:
+      - image: postgres:10
+        environment:
+          - POSTGRES_VERSION: 10
+  test-11:
+    <<: *test-template
+    docker:
+      - image: postgres:11
+        environment:
+          - POSTGRES_VERSION: 11
+  test-12:
+    <<: *test-template
+    docker:
+      - image: postgres:12
+        environment:
+          - POSTGRES_VERSION: 12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,17 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-9.6
       - test-10
       - test-11
       - test-12
 
 jobs:
-  test-9.6: &test-template
+  test-10: &test-template
     working_directory: ~/postgres_dba
     docker:
-      - image: postgres:9.6
+      - image: postgres:10
         environment:
-          - POSTGRES_VERSION: 9.6
+          - POSTGRES_VERSION: 10
     steps:
       - checkout
       - run:
@@ -45,12 +44,6 @@ jobs:
             diff -b test/regression/0_node.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/0_node.sql | grep Role)
             diff -b test/regression/p1_alignment_padding.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/p1_alignment_padding.sql | grep align)
             diff -b test/regression/a1_activity.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/a1_activity.sql | grep User)
-  test-10:
-    <<: *test-template
-    docker:
-      - image: postgres:10
-        environment:
-          - POSTGRES_VERSION: 10
   test-11:
     <<: *test-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
           command: |
             psql -U postgres -c 'create database test'
             psql -U postgres test -c 'create extension pg_stat_statements'
+            psql -U postgres test -c 'create extension pgstattuple'
             psql -U postgres test -c "create table align1 as select 1::int4, 2::int8, 3::int4 as more from generate_series(1, 100000) _(i);"
             psql -U postgres test -c "create table align2 as select 1::int4, 3::int4 as more, 2::int8 from generate_series(1, 100000) _(i);"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,20 @@ jobs:
     docker:
       - image: postgres:12
         environment:
-          - PGHOST: 127.0.0.1
-          - PGUSER: root
+          - POSTGRES_VERSION: 12
+          - POSTGRES_USER: root
     steps:
       - checkout
+      - runL
+          name: Init DB
+          command: |
+            pg_createcluster $POSTGRES_VERSION main
+            echo 'local all all trust' > /etc/postgresql/$POSTGRES_VERSION/main/pg_hba.conf
+            pg_ctlcluster $POSTGRES_VERSION main start
       - run:
           name: Prepare DB
           command: |
+            psql postgres -c 'create database test'
             psql test -c "create table align1 as select 1::int4, 2::int8, 3::int4 as more from generate_series(1, 100000) _(i);"
             psql test -c "create table align2 as select 1::int4, 3::int4 as more, 2::int8 from generate_series(1, 100000) _(i);"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
       - image: postgres:12
         environment:
           - POSTGRES_VERSION: 12
-          - POSTGRES_USER: root
     steps:
       - checkout
       - run:
@@ -18,16 +17,16 @@ jobs:
       - run:
           name: Prepare DB
           command: |
-            psql postgres -c 'create database test'
-            psql test -c "create table align1 as select 1::int4, 2::int8, 3::int4 as more from generate_series(1, 100000) _(i);"
-            psql test -c "create table align2 as select 1::int4, 3::int4 as more, 2::int8 from generate_series(1, 100000) _(i);"
+            psql -U postgres -c 'create database test'
+            psql -U postgres test -c "create table align1 as select 1::int4, 2::int8, 3::int4 as more from generate_series(1, 100000) _(i);"
+            psql -U postgres test -c "create table align2 as select 1::int4, 3::int4 as more, 2::int8 from generate_series(1, 100000) _(i);"
       - run:
           name: Tests
           command: |
             #  echo "\set postgres_dba_wide true" > ~/.psqlrc
-            #for f in ~/postgres_dba/sql/*; do psql test -f "$f">/dev/null; done
+            #for f in ~/postgres_dba/sql/*; do psql -U postgres test -f "$f">/dev/null; done
             #echo "\set postgres_dba_wide false" > ~/.psqlrc
-            #for f in ~/postgres_dba/sql/*; do psql test -f "$f">/dev/null; done
-            diff -b test/regression/0_node.out <(psql test -f warmup.psql -f ~/postgres_dba/sql/0_node.sql | grep Role)
-            diff -b test/regression/p1_alignment_padding.out <(psql test -f warmup.psql -f ~/postgres_dba/sql/p1_alignment_padding.sql | grep align)
-            diff -b test/regression/a1_activity.out <(psql test -f warmup.psql -f ~/postgres_dba/sql/a1_activity.sql | grep User)
+            #for f in ~/postgres_dba/sql/*; do psql -U postgres test -f "$f">/dev/null; done
+            diff -b test/regression/0_node.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/0_node.sql | grep Role)
+            diff -b test/regression/p1_alignment_padding.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/p1_alignment_padding.sql | grep align)
+            diff -b test/regression/a1_activity.out <(psql -U postgres test -f warmup.psql -f ~/postgres_dba/sql/a1_activity.sql | grep User)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,25 +3,12 @@ jobs:
   build:
     working_directory: ~/postgres_dba
     docker:
-      - image: circleci/ruby:2.4.1-node
+      - image: circleci/postgres:12
         environment:
           - PGHOST: 127.0.0.1
           - PGUSER: root
-      - image: circleci/postgres:10
-        environment:
-          - POSTGRES_USER: root
-          - POSTGRES_DB: test
     steps:
       - checkout
-      - run:
-          name: Install psql
-          command: |
-            sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
-            wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-            sudo apt-get update
-            sudo apt install postgresql-client
-            psql test -c 'create extension pg_stat_statements;'
-            psql test -c 'create extension pgstattuple;'
       - run:
           name: Prepare DB
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           - POSTGRES_USER: root
     steps:
       - checkout
-      - runL
+      - run:
           name: Init DB
           command: |
             pg_createcluster $POSTGRES_VERSION main

--- a/sql/b1_table_estimation.sql
+++ b/sql/b1_table_estimation.sql
@@ -22,16 +22,17 @@ with step1 as (
     case when version() ~ 'mingw32|64-bit|x86_64|ppc64|ia64|amd64' then 8 else 4 end as ma, -- NS: TODO: check it
     24 as page_hdr,
     23 + case when max(coalesce(null_frac, 0)) > 0 then (7 + count(*)) / 8 else 0::int end
-      + case when tbl.relhasoids then 4 else 0 end as tpl_hdr_size,
+      + case when bool_or(att.attname = 'oid' and att.attnum < 0) then 4 else 0 end as tpl_hdr_size,
     sum((1 - coalesce(s.null_frac, 0)) * coalesce(s.avg_width, 1024)) as tpl_data_size,
-    bool_or(att.atttypid = 'pg_catalog.name'::regtype) or count(att.attname) <> count(s.attname) as is_na
+    bool_or(att.atttypid = 'pg_catalog.name'::regtype)
+      or sum(case when att.attnum > 0 then 1 else 0 end) <> count(s.attname) as is_na
   from pg_attribute as att
   join pg_class as tbl on att.attrelid = tbl.oid and tbl.relkind = 'r'
   join pg_namespace as ns on ns.oid = tbl.relnamespace
   join pg_stats as s on s.schemaname = ns.nspname and s.tablename = tbl.relname and not s.inherited and s.attname = att.attname
   left join pg_class as toast on tbl.reltoastrelid = toast.oid
-  where att.attnum > 0 and not att.attisdropped and s.schemaname not in ('pg_catalog', 'information_schema')
-  group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, tbl.relhasoids
+  where not att.attisdropped and s.schemaname not in ('pg_catalog', 'information_schema')
+  group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
   order by 2, 3
 ), step2 as (
   select

--- a/sql/p1_alignment_padding.sql
+++ b/sql/p1_alignment_padding.sql
@@ -64,14 +64,14 @@ with recursive constants as (
     table_name,
     0 as analyzed,
     (select chunk_size from constants) as left_in_chunk,
-    '{}'::text[] as padded_columns,
+    '{}'::text[] collate "C" as padded_columns,
     '{}'::int[] as pads,
     (select max(ordinal_position) from columns c where c.table_name = _.table_name and c.table_schema = _.table_schema) as col_cnt,
     array_agg(_.column_name::text order by ordinal_position) as cols,
     array_agg(_.udt_name::text order by ordinal_position) as types,
     array_agg(shift order by ordinal_position) as shifts,
     null::int as curleft,
-    null::text as prev_column_name,
+    null::text collate "C" as prev_column_name,
     false as has_varlena
   from
     combined_columns _

--- a/start.psql
+++ b/start.psql
@@ -1,3 +1,4 @@
+\set postgres_dba_interactive_mode true
 \ir warmup.psql
 \echo '\033[1;35mMenu:\033[0m'
 \echo '   0 – Node & Current DB Information: master/replica, lag, DB size, tmp files, etc'


### PR DESCRIPTION
Issue: https://github.com/NikolayS/postgres_dba/issues/43

- Now the tool is tested in CirclecI for multiple Postgres versions: 10, 11, 12
- Fixed problem for report b1 in Postgres 12
- Fixed problem for report p1 in Postgres 12

### PostgreSQL 12 errors

Two errors fixed, in b1 and in p1:
```
psql:/var/lib/pgsql/postgres_dba/sql/b1_table_estimation.sql:99: ERROR:  column tbl.relhasoids does not exist
LINE 19:       + case when tbl.relhasoids then 4 else 0 end as tpl_hd...


psql:/root/postgres_dba/sql/p1_alignment_padding.sql:197: ERROR:  recursive query "analyze_alignment" column 13 has collation "default" in non-recursive term but collation "C" overall
LINE 68:     null::text as prev_column_name,
             ^
HINT:  Use the COLLATE clause to set the collation of the non-recursive term.
```