### PR TITLE
Fix the section about installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Using alternative psql pager called "pspg" is highly recommended (but not requir
 The installation is trivial. Clone the repository and put "dba" alias to your `.psqlrc` file:
 ```bash
 git clone https://github.com/NikolayS/postgres_dba.git
-echo "\\set dba '\\\\i `pwd`/postgres_dba/start.psql'" >> ~/.psqlrc
+echo "\\set dba '\\\\\\i `pwd`/postgres_dba/start.psql'" >> ~/.psqlrc
 ```
 
 That's it.


### PR DESCRIPTION
Another slash is required when escaping for "\i"